### PR TITLE
inject REDIS_HOST and SCONE_CONFIG_ID in environment

### DIFF
--- a/broker/plugins/kubejobs/plugin.py
+++ b/broker/plugins/kubejobs/plugin.py
@@ -55,6 +55,14 @@ class KubeJobsExecutor(GenericApplicationExecutor):
             # e.g. api.redis_creation_timeout.
             redis_ip, redis_port = k8s.provision_redis_or_die(self.app_id)
 
+            # inject REDIS_HOST in the environment
+            data['env_vars']['REDIS_HOST'] = 'redis-%s' % self.app_id
+
+            # inject SCONE_CONFIG_ID in the environment
+            # FIXME: make SCONE_CONFIG_ID optional in submission
+            data['env_vars']['SCONE_CONFIG_ID'] = data['config_id']
+
+            # create a new Redis client and fill the work queue
             self.rds = redis.StrictRedis(host=redis_ip, port=redis_port)
             queue_size = len(jobs)
 

--- a/broker/utils/plugins/k8s.py
+++ b/broker/utils/plugins/k8s.py
@@ -37,7 +37,6 @@ def create_job(app_id, cmd, img, init_size, env_vars,
     obj_meta = kube.client.V1ObjectMeta(
         name=app_id)
     
-        
     envs = []
 
     for key in env_vars.keys():
@@ -47,10 +46,6 @@ def create_job(app_id, cmd, img, init_size, env_vars,
                 value=env_vars[key])
 
         envs.append(var)
-
-    # add redis address to ``args``
-    cmd.append("redis-%s" % app_id)
-    cmd.append(config_id)
 
     isgx = kube.client.V1VolumeMount(
         mount_path="/dev/isgx",


### PR DESCRIPTION
previously the manager would pass REDIS_HOST and SCONE_CONFIG_ID
to the worker as command line arguments. make it pass them as
environment variables, to avoid coupling and allow more generic apps.