### PR TITLE
Adapting the Manager to be able to stop a stream plugin

### DIFF
--- a/kubejobs/__init__.py
+++ b/kubejobs/__init__.py
@@ -309,6 +309,7 @@ class KubeJobsExecutor(base.GenericApplicationExecutor):
 
     def stop_application(self):
         self.rds.delete("job")
+        self.rds.rpush("stop","stop")
 
     def errors(self):
         try:

--- a/kubejobs/__init__.py
+++ b/kubejobs/__init__.py
@@ -309,7 +309,7 @@ class KubeJobsExecutor(base.GenericApplicationExecutor):
 
     def stop_application(self):
         self.rds.delete("job")
-        self.rds.rpush("stop","stop")
+        self.rds.rpush("stop", "stop")
 
     def errors(self):
         try:


### PR DESCRIPTION
Adapting the Manager to be able to stop a stream plugin, this is done by sending a flag to a specific key in redis. The stream apps, must from now on, look at that redis key to know when to stop