### PR TITLE
Add support to install private plugins

### DIFF
--- a/broker/api/v10.py
+++ b/broker/api/v10.py
@@ -22,6 +22,7 @@ rest = u.Rest('v10', __name__)
 
 CORS(rest, expose_headers='Authorization')
 
+
 @rest.get('/key')
 def get_ssh_key():
     return jsonify(api.get_ssh_key())

--- a/broker/api/v10.py
+++ b/broker/api/v10.py
@@ -22,6 +22,10 @@ rest = u.Rest('v10', __name__)
 
 CORS(rest, expose_headers='Authorization')
 
+@rest.get('/key')
+def get_ssh_key():
+    return jsonify(api.get_ssh_key())
+
 
 @rest.post('/plugins')
 def install_plugin(data):

--- a/broker/service/api/v10.py
+++ b/broker/service/api/v10.py
@@ -33,6 +33,7 @@ API_LOG = Log("APIv10", "logs/APIv10.log")
 clusters = {}
 activated_cluster = None
 
+SSH_KEY_PATH = '/root/.ssh/id_rsa.pub'
 
 CLUSTER_CONF_PATH = "./data/clusters"
 
@@ -72,6 +73,13 @@ def install_plugin(data):
     elif component == plugin_service.Components.CONTROLLER:
         response = plugin_service.install_in_controller(source, plugin_repo)
         return response.json(), response.status_code
+
+
+def get_ssh_key():
+    with open(SSH_KEY_PATH) as f:
+        key = f.read()
+
+    return {"key": key.strip()}
 
 
 def run_submission(data):

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+cp ssh_config ~/.ssh/config
+printf '\n\n\n\n\n\n' | ssh-keygen
+
 tox -e venv -- broker

--- a/ssh_config
+++ b/ssh_config
@@ -1,0 +1,2 @@
+Host github.com
+    StrictHostKeyChecking no

--- a/ssh_config
+++ b/ssh_config
@@ -1,2 +1,4 @@
 Host github.com
     StrictHostKeyChecking no
+Host git.lsd.ufcg.edu.br
+    StrictHostKeyChecking no


### PR DESCRIPTION
This PR is able to make Manager able to install private plugins by generating a SSH key when it runs for the first time.
User can use `/key` to get the public key and put in their git account, so the Manager will be able to clone any private repository from that account.
In order to do that, the user must configure `ssh_config` file to indicate what hosts are trusted. By default, only github is.