### PR TITLE
Fixed job status retrieval on the start of the job

### DIFF
--- a/kubejobs/__init__.py
+++ b/kubejobs/__init__.py
@@ -460,7 +460,9 @@ class KubeJobsExecutor(base.GenericApplicationExecutor):
                 return
             except Exception:
                 if remaining_attempts == 0:
-                    KUBEJOBS_LOG.log("Could not get job status after %d attempts." % total_number_of_attempts)
+                    KUBEJOBS_LOG.log(
+                        "Could not get job status after {} attempts."
+                        .format(total_number_of_attempts))
                     self.terminated = True
                     final_states = ['completed', 'failed',
                                     'error', 'created', 'stopped']


### PR DESCRIPTION
Sometimes the job status retrieval fails on the start of the job execution (probably job information was not ready on kubernetes master) and the manager uses not found, an error status, as final status. So it is necessary to try a few more times before deciding that the job actually failed.